### PR TITLE
[Change] Add logic calc nutrient based on recipe used

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -1,5 +1,14 @@
-import { CalcRealCostByBasePrice, CalcRealNutrientsInAnItem, CalcTotalNutrientFacts, GetLowestCostByIngredient, LowestCostProduct, sortObjectKeys } from "./helpers";
-import { GetRecipes } from "./supporting-files/data-access";
+import {
+  CalcRealCostByBasePrice,
+  CalcRealNutrientsInAnItem,
+  CalcTotalNutrientFacts,
+  ConvertMultiUnits,
+  GetLowestCostByIngredient,
+  LowestCostProduct,
+  sortObjectKeys
+} from "./helpers";
+import { GetRecipes, NutrientBaseUoM } from "./supporting-files/data-access";
+import { SumUnitsOfMeasure } from "./supporting-files/helpers";
 import { Recipe, UnitOfMeasure } from "./supporting-files/models";
 import { ExpectedRecipeSummary, RunTest } from "./supporting-files/testing";
 
@@ -21,6 +30,11 @@ const baseIngredientPricing: { [key: string]: LowestCostProduct } = {};
 
 const calcAnRecipeSummary = (recipe: Recipe) => {
   let totalCost = 0;
+  let totalQtyOfRecipe: UnitOfMeasure = {
+    uomAmount: 0,
+    uomName: NutrientBaseUoM.uomName,
+    uomType: NutrientBaseUoM.uomType
+  };
   const nutrients: { [key: string]: UnitOfMeasure } = {}; // total nutrients used in this recipe
 
   for (const lineItem of recipe.lineItems) {
@@ -46,6 +60,9 @@ const calcAnRecipeSummary = (recipe: Recipe) => {
       if (!nutrients[nutrientName]) nutrients[nutrientName] = realNutrients[nutrientName];
       else nutrients[nutrientName].uomAmount += realNutrients[nutrientName].uomAmount;
     }
+    const convertedItem = ConvertMultiUnits(lineItem.unitOfMeasure, totalQtyOfRecipe.uomName, totalQtyOfRecipe.uomType);
+
+    totalQtyOfRecipe = SumUnitsOfMeasure(totalQtyOfRecipe, convertedItem);
   }
 
   // calc total nutrients

--- a/main.ts
+++ b/main.ts
@@ -53,7 +53,7 @@ const calcAnRecipeSummary = (recipe: Recipe) => {
     totalCost += CalcRealCostByBasePrice(lineItem.unitOfMeasure, lowestCostProduct.basePrice);
 
     // ----------calc nutrients of line item----------
-    const realNutrients = CalcRealNutrientsInAnItem(lowestCostProduct.nutrientFacts);
+    const realNutrients = CalcRealNutrientsInAnItem(lineItem.unitOfMeasure, lowestCostProduct.nutrientFacts);
 
     // ----------sum nutrients & sum qty----------
     for (const nutrientName in realNutrients) {
@@ -66,7 +66,7 @@ const calcAnRecipeSummary = (recipe: Recipe) => {
   }
 
   // calc total nutrients
-  const nutrientFacts = CalcTotalNutrientFacts(nutrients);
+  const nutrientFacts = CalcTotalNutrientFacts(nutrients, totalQtyOfRecipe);
 
   // summarize
   const recipeDetail = {


### PR DESCRIPTION
>All command below just based on my opinion and depend on my knowledge. It can be a mistake from me, please consider that as a discussion, not the answer.

## Pre:

- Recipe R need two line item: 10 grams A, 20 grams B
- A contain: 5 grams Sodium per 100 grams A
- B contain: 15 grams Sodium per 100 grams B

## What: 

- Calculate the nutrient fact for an pack 1 of A

Current formula:

 ```Sodium = 5 +15 = 20 grams per 100 grams```

## Problem:

  - Depend on my knowledge, this formula is not correct business logic for calc nutrient
  - Quantity between A and B is difference on the recipe, so the combination is not enough for this case.
  - Recipe R using specific quantity of A, B, so 100 grams must be based on grams of recipe

## My change:

- Calc nutrient based on grams of recipe R.
    
    ``` Sodium = (5 / 100 * 10 + 15 / 100 * 20) / (10+20) * 100 = X per 100 grams of R```
    
- Please check the code below to see more detail